### PR TITLE
workaround: retry manifest upload on quay

### DIFF
--- a/oras/provider.py
+++ b/oras/provider.py
@@ -840,6 +840,9 @@ class Registry:
         response = self.upload_manifest(
             manifest, container
         )  # make the returned response from this method, the one pertaining to the uploaded Manifest
+        if response.status_code == 500:
+            # retry once
+            response = self.upload_manifest(manifest, container)
         self._check_200_response(response)
         print(f"Successfully pushed {container}")
         return response


### PR DESCRIPTION
For the record it seems that the `oras` CLI does this automatically as observed via WireShark:

![image](https://github.com/user-attachments/assets/fe2fd357-b3d1-4e6b-a3c7-6bbc07bb1c44)

From my investigations I figured it should be coming from [oras-project/oras-go](https://github.com/oras-project/oras-go/blob/bf570bcc78b3aa1bad84401e3390cc79a03e426e/registry/remote/retry/policy.go#L56).

Tested with a local instance and also with Quay.io successfully following https://github.com/isinyaaa/quay-demo.git
Remote upload https://quay.io/repository/idoamara/testrepo verified with `oras cp quay.io/idoamara/testrepo:v1 --to-oci-layout testrepo-mirror`